### PR TITLE
Added the optional "@attr" with the "user.getRecentTracks" response

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1244,6 +1244,9 @@ export type LastFMUserGetRecentTracksResponse = Readonly<{
 				uts: string;
 				'#text': string;
 			};
+			'@attr'?: {
+				nowplaying: "true"
+			};
 		}>;
 		'@attr': {
 			user: string;


### PR DESCRIPTION
The api returns an optional "@attr" with the "user.getRecentTracks" method if the user is currently playing a song
i've checked this on my personal account