### PR TITLE
feat: Add user configurable request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ const track = new LastFMTrack('API_KEY', 'SECRET', 'SESSION_KEY', {
 
 **Note:** In order to interact with another scrobbling platform you need to supply an API key for that platform.
 
+## Timeout
+
+Optionally, supply the maximum number of milliseconds which a request can take to complete. This can be useful if your application needs quick responses or to fail fast.
+
+```ts
+// To interact with the Track API:
+import { LastFMTrack } from 'lastfm-ts-api';
+
+const track = new LastFMTrack('API_KEY', 'SECRET', 'SESSION_KEY', {
+    timeout: 3000 // timeout request after 3 seconds, throws an exception
+});
+```
+
 ## LICENSE
 
 MIT

--- a/src/api-request.ts
+++ b/src/api-request.ts
@@ -160,6 +160,10 @@ export class LastFMApiRequest<T> {
 			path: this.config.path ?? '/2.0'
 		};
 
+		if(this.config.timeout !== undefined) {
+			options.signal = AbortSignal.timeout(this.config.timeout);
+		}
+
 		if (method === 'POST') {
 			options.method = 'POST';
 			options.headers = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1447,6 +1447,7 @@ export type LastFMUserGetWeeklyTrackChartResponse = Readonly<{
 }>;
 
 export type OptionalConfig = {
-	hostname: string;
-	path: string;
+	hostname?: string;
+	path?: string;
+	timeout?: number;
 };


### PR DESCRIPTION
Provides a user-configurable [AbortSignal](https://nodejs.org/api/globals.html#class-abortsignal) to the lastfm [api request options](https://nodejs.org/api/http.html#httprequesturl-options-callback) so that the request can be failed fast if it takes too long.

This can happen if lastfm is just be generally slow or if the user is requesting a large number of tracks/scrobbles.