### PR TITLE
fix: More inclusive json mime type

### DIFF
--- a/src/api-request.ts
+++ b/src/api-request.ts
@@ -91,9 +91,9 @@ export class LastFMApiRequest<T> {
 
 			httpRequest.end();
 		}).then(([response, content]) => {
-			if (response.headers['content-type'] !== 'application/json') {
+			if (!response.headers['content-type']?.includes('application/json')) {
 				throw new LastFMResponseError(
-					`lastfm-ts-api: Expected JSON response but received '${response.headers['content-type']}'`,
+					`lastfm-ts-api: Expected JSON response ('application/json') but received '${response.headers['content-type']}'`,
 					{ response, content }
 				);
 			}


### PR DESCRIPTION
Instead of exact json type response is now checked that it includes application/json as a substring of Content-Type. Allows more variants like charset.

This is needed for libre.fm which, annoyingly, is now returning `application/json; charset=utf-8` and causing responses from lastfm-ts-api to fail.